### PR TITLE
Revert hooks to how they looked in vivid

### DIFF
--- a/hybris/common/dlfcn.c
+++ b/hybris/common/dlfcn.c
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2013 Intel Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+#include <../include/hybris/dlfcn/dlfcn.h>
+#include <../include/hybris/common/binding.h>
+
+void *hybris_dlopen(const char *filename, int flag)
+{
+    return android_dlopen(filename,flag);
+}
+
+
+void *hybris_dlsym(void *handle, const char *symbol)
+{
+    return android_dlsym(handle,symbol);
+}
+
+
+int   hybris_dlclose(void *handle)
+{
+    return android_dlclose(handle);
+}
+
+
+char *hybris_dlerror(void)
+{
+    return android_dlerror();
+}
+
+// vim: noai:ts=4:sw=4:ss=4:expandtab

--- a/hybris/common/hooks_shm.h
+++ b/hybris/common/hooks_shm.h
@@ -19,12 +19,11 @@
 #define HOOKS_SHM_H_
 
 #include <stddef.h>
-#include <stdint.h>
 
 /* Leave space to workaround the issue that Android might pass negative int values */
-#define HYBRIS_SHM_MASK_TOP (UINTPTR_MAX - 15)
+#define HYBRIS_SHM_MASK_TOP 0xFFFFFFF0UL
 
-typedef uintptr_t hybris_shm_pointer_t;
+typedef unsigned int hybris_shm_pointer_t;
 
 /* 
  * Allocate a space in the shared memory region of hybris


### PR DESCRIPTION
This fixes https://github.com/ubports/ubuntu-touch/issues/667 and https://github.com/ubports/ubuntu-touch/issues/665 and https://github.com/ubports/ubuntu-touch/issues/582

And might even have positive effect on https://github.com/ubports/ubuntu-touch/issues/611 and https://github.com/ubports/ubuntu-touch/issues/514

This will need testing on a handful of different devices, since it's a critical part.