### PR TITLE
Simply ignore fflush if fp is null

### DIFF
--- a/hybris/common/hooks.c
+++ b/hybris/common/hooks.c
@@ -1425,6 +1425,10 @@ static int _hybris_hook_fflush(FILE *fp)
 {
     TRACE_HOOK("fp %p", fp);
 
+    if (fp == NULL) {
+        return 0;
+    }
+
     if(fileno(_get_actual_fp(fp)) < 0) {
         return 0;
     }


### PR DESCRIPTION
We seems to have some faulty blobs that somehow sends an empty fp to
fflush. This ignores that and moves on.