### PR TITLE
Fix compilation without NativeBufferAlloc.h

### DIFF
--- a/compat/camera/camera_compatibility_layer.cpp
+++ b/compat/camera/camera_compatibility_layer.cpp
@@ -50,8 +50,9 @@
 #include <utils/KeyedVector.h>
 #include <utils/Log.h>
 #include <utils/String16.h>
-
+#if ANDROID_VERSION_MAJOR==4 && ANDROID_VERSION_MINOR<=3
 #include <gui/NativeBufferAlloc.h>
+#endif
 
 #include <cstring>
 
@@ -145,6 +146,7 @@ void CameraControl::postRecordingFrameHandleTimestamp(nsecs_t /*timestamp*/, nat
 	REPORT_FUNCTION();
 }
 
+#if ANDROID_VERSION_MAJOR==4 && ANDROID_VERSION_MINOR<=3
 namespace android
 {
 NativeBufferAlloc::NativeBufferAlloc() {
@@ -170,6 +172,7 @@ sp<GraphicBuffer> NativeBufferAlloc::createGraphicBuffer(uint32_t w, uint32_t h,
 	return graphicBuffer;
 }
 }
+#endif
 
 int android_camera_get_number_of_devices()
 {
@@ -692,9 +695,11 @@ void android_camera_set_preview_texture(CameraControl* control, int texture_id)
 	static const bool allow_synchronous_mode = false;
 	static const bool is_controlled_by_app = true;
 
+#if ANDROID_VERSION_MAJOR==4 && ANDROID_VERSION_MINOR<=3
 	android::sp<android::NativeBufferAlloc> native_alloc(
 			new android::NativeBufferAlloc()
 			);
+#endif
 
 #if ANDROID_VERSION_MAJOR>=5
 	android::sp<android::IGraphicBufferProducer> producer;

--- a/compat/camera/direct_camera_test.cpp
+++ b/compat/camera/direct_camera_test.cpp
@@ -675,6 +675,7 @@ int main(int argc, char** argv)
 
 	while (1) {
 		usleep(50);
+		preview_texture_needs_update_cb(0);
 	}
 
 	stop_video_recording(recorder);

--- a/compat/media/Android.mk
+++ b/compat/media/Android.mk
@@ -109,6 +109,7 @@ LOCAL_C_INCLUDES := \
 	frameworks/av/media/libstagefright/include \
 	frameworks/av/include \
 	frameworks/native/include \
+	frameworks/native/include/media/hardware \
 	system/media/audio_utils/include \
 	frameworks/av/services/camera/libcameraservice
 

--- a/compat/media/decoding_service.cpp
+++ b/compat/media/decoding_service.cpp
@@ -38,7 +38,9 @@ typedef void* EGLSyncKHR;
 #include <gui/IGraphicBufferProducer.h>
 #include <gui/IGraphicBufferConsumer.h>
 #include <gui/Surface.h>
+#if ANDROID_VERSION_MAJOR==4 && ANDROID_VERSION_MINOR<=3
 #include <gui/NativeBufferAlloc.h>
+#endif
 
 namespace android {
 

--- a/compat/media/media_compatibility_layer.cpp
+++ b/compat/media/media_compatibility_layer.cpp
@@ -44,10 +44,13 @@
 
 #include <utils/Log.h>
 
+#if ANDROID_VERSION_MAJOR==4 && ANDROID_VERSION_MINOR<=3
 #include <gui/NativeBufferAlloc.h>
+#endif
 
 #define REPORT_FUNCTION() ALOGV("%s \n", __PRETTY_FUNCTION__)
 
+#if ANDROID_VERSION_MAJOR==4 && ANDROID_VERSION_MINOR<=3
 namespace android
 {
 NativeBufferAlloc::NativeBufferAlloc() {
@@ -73,6 +76,8 @@ sp<GraphicBuffer> NativeBufferAlloc::createGraphicBuffer(uint32_t w, uint32_t h,
 	return graphicBuffer;
 }
 }
+#endif
+
 #if ANDROID_VERSION_MAJOR==4 && ANDROID_VERSION_MINOR<=2
 struct FrameAvailableListener : public android::SurfaceTexture::FrameAvailableListener
 #else
@@ -490,15 +495,16 @@ int android_media_set_preview_texture(MediaPlayerWrapper *mp, int texture_id)
 		return BAD_VALUE;
 	}
 
-	android::sp<android::NativeBufferAlloc> native_alloc(
-			new android::NativeBufferAlloc()
-			);
-
 #if ANDROID_VERSION_MAJOR>=5
 	android::sp<IGraphicBufferProducer> producer;
 	android::sp<IGraphicBufferConsumer> consumer;
 	BufferQueue::createBufferQueue(&producer, &consumer);
 #else
+#if ANDROID_VERSION_MAJOR==4 && ANDROID_VERSION_MINOR<=3
+    android::sp<android::NativeBufferAlloc> native_alloc(
+            new android::NativeBufferAlloc()
+            );
+#endif
 	android::sp<android::BufferQueue> buffer_queue(
 #if ANDROID_VERSION_MAJOR==4 && ANDROID_VERSION_MINOR<=3
 			new android::BufferQueue(false, NULL, native_alloc)


### PR DESCRIPTION
NativeBufferAlloc was not used in Android 5 and newer codepaths, so do not include the header file for them.