### PR TITLE
[debian] fixes -dev packages' dependency

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+libhybris (0.1.3+ubports2) xenial; urgency=medium
+
+  * Compile with android-28 headers for Halium 9
+
+ -- TheKit <nekit1000@@gmail.com>  Sat, 21 Mar 2020 22:36:24 +0100
+
 libhybris (0.1.3+ubports1) xenial; urgency=medium
 
   * Update to upstream libhybris

--- a/debian/control
+++ b/debian/control
@@ -51,7 +51,7 @@ Package: libmedia-dev
 Section: libdevel
 Architecture: armhf arm64 i386 amd64
 Depends: libmedia1 (= ${binary:Version}),
-         android-headers-27,
+         android-headers-28,
          ${misc:Depends}
 Replaces: libhybris-dev (<< 0.1.0+git20130606+c5d897a-0ubuntu24)
 Breaks: libhybris-dev (<< 0.1.0+git20130606+c5d897a-0ubuntu24)
@@ -80,7 +80,7 @@ Package: libhardware-dev
 Section: libdevel
 Architecture: armhf arm64 i386 amd64
 Depends: libhardware2 (= ${binary:Version}),
-         android-headers-27,
+         android-headers-28,
          ${misc:Depends}
 Replaces: libhybris-dev (<< 0.1.0+git20130606+c5d897a-0ubuntu13)
 Breaks: libhybris-dev (<< 0.1.0+git20130606+c5d897a-0ubuntu13)
@@ -135,7 +135,7 @@ Package: libhybris-dev
 Section: libdevel
 Architecture: armhf arm64 i386 amd64
 Depends: libhybris (= ${binary:Version}),
-         android-headers-27,
+         android-headers-28,
          libandroid-properties-dev (= ${binary:Version}),
          libhardware-dev (= ${binary:Version}),
          libmedia-dev (= ${binary:Version}),

--- a/debian/control
+++ b/debian/control
@@ -4,7 +4,7 @@ Maintainer: Ubuntu Developers <ubuntu-devel-discuss@lists.ubuntu.com>
 Build-Depends: debhelper (>= 9.0.0),
                autotools-dev,
                dh-autoreconf,
-               android-headers-27,
+               android-headers-28,
                quilt,
                pkg-config,
                libgles2-mesa-dev,

--- a/debian/rules
+++ b/debian/rules
@@ -67,7 +67,7 @@ get-packaged-orig-source:
 		| gzip >../$(PKG_source)_$(UPS_version).orig.tar.gz
 	rm -rf $(PKG_source)-$(UPS_version)
 
-ANDROID_HEADERS_PATH = /usr/include/android-27
+ANDROID_HEADERS_PATH = /usr/include/android-28
 DEFAULT_CONFIGURATION = \
 	--enable-wayland \
 	--with-android-headers=$(ANDROID_HEADERS_PATH) \


### PR DESCRIPTION
Depends on the correct android-headers package for all -dev packages

Also see #19.